### PR TITLE
CI - Make python 3.7  run on Ubuntu 22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,11 +33,14 @@ jobs:
         conda run -n test make lint
 
   tests:
-    runs-on: ubuntu-latest
     strategy:
         max-parallel: 10
         matrix:
           python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+          include:
+            - python-version: "3.7"
+              os: ubuntu-22.04
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,14 +33,10 @@ jobs:
         conda run -n test make lint
 
   tests:
+    runs-on: 'ubuntu-latest'
     strategy:
         max-parallel: 10
-        matrix:
-          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-          include:
-            - python-version: "3.7"
-              os: ubuntu-22.04
-    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+          python-version: ["3.9", "3.10", "3.11","3.12","3.13"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
 
     - name: Add conda to system path
       run: |
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version:  ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
         max-parallel: 10
         matrix:
-          python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+          python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
[setup-python](https://github.com/actions/setup-python) for `python=3.7` doesn't run on `ubuntu-latest` (24.04).
This PR adds an exception for that.
It also bumps setup-action from `@v3` to `@v5`